### PR TITLE
Update Keys & Location

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,6 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "eeue56/elm-all-dict": "2.0.1 <= v < 3.0.0",
         "elm-lang/animation-frame": "1.0.1 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",

--- a/src/elm/Keys.elm
+++ b/src/elm/Keys.elm
@@ -1,57 +1,60 @@
-module Keys exposing (Keys, Key(..), updateKeys, init)
+module Keys exposing (Keys, GameKey(..), updateKeys, init, updateFromKeyCode, pressedKeys)
 
-import Char exposing (fromCode)
+import Char exposing (fromCode, KeyCode)
+import EveryDict exposing (EveryDict)
 
 
-type Key
-    = Down Int
-    | Up Int
+--  I'm not really using the 'value' in this dict, key existance is kind of all that matters rn
+
+
+type GameKey
+    = Left
+    | Right
+    | Up
+    | Down
+
+
+type alias Pressed =
+    Bool
 
 
 type alias Keys =
-    { down : Bool
-    , left : Bool
-    , right : Bool
-    , up : Bool
-    }
+    EveryDict GameKey Pressed
 
 
 init : Keys
 init =
-    { down = False
-    , left = False
-    , right = False
-    , up = False
-    }
+    EveryDict.empty
 
 
-updateKeys : Key -> Keys -> Keys
-updateKeys key keys =
-    case key of
-        Down keyCode ->
-            keys
-                |> applyKeyChange keyCode True
-
-        Up keyCode ->
-            keys
-                |> applyKeyChange keyCode False
+updateKeys : GameKey -> Pressed -> Keys -> Keys
+updateKeys key pressed dict =
+    if pressed then
+        EveryDict.insert key pressed dict
+    else
+        EveryDict.remove key dict
 
 
-applyKeyChange : Int -> Bool -> Keys -> Keys
-applyKeyChange keyCode pressed currentKeys =
+updateFromKeyCode : Int -> Pressed -> Keys -> Keys
+updateFromKeyCode keyCode pressed currentKeys =
     case fromCode keyCode of
         'A' ->
-            { currentKeys | left = pressed }
+            updateKeys Left pressed currentKeys
 
         'W' ->
-            { currentKeys | up = pressed }
+            updateKeys Up pressed currentKeys
 
         'S' ->
-            { currentKeys | down = pressed }
+            updateKeys Down pressed currentKeys
 
         'D' ->
-            { currentKeys | right = pressed }
+            updateKeys Right pressed currentKeys
 
         -- For some reason, we don't catch arrow keys...growl
         _ ->
             currentKeys
+
+
+pressedKeys : Keys -> List GameKey
+pressedKeys keys =
+    EveryDict.keys keys

--- a/src/elm/Location.elm
+++ b/src/elm/Location.elm
@@ -7,10 +7,22 @@ type alias Vector =
     }
 
 
+toVector : ( Float, Float ) -> Vector
+toVector ( x, y ) =
+    { dx = Magnitude x
+    , dy = Magnitude y
+    }
+
+
 type alias Location =
     { x : Coordinate
     , y : Coordinate
     }
+
+
+defaultBoundary : Float
+defaultBoundary =
+    200
 
 
 unwrapLocation : Location -> { x : Float, y : Float }
@@ -47,4 +59,16 @@ applyVector { dx, dy } { x, y } =
 
 applyMagnitude : Coordinate -> Magnitude -> Coordinate
 applyMagnitude (Coordinate pos) (Magnitude impulse) =
-    Coordinate (pos + impulse)
+    let
+        attemptedPos =
+            pos + impulse
+
+        actualPosition =
+            if attemptedPos > defaultBoundary then
+                defaultBoundary
+            else if attemptedPos < (defaultBoundary * -1) then
+                defaultBoundary * -1
+            else
+                attemptedPos
+    in
+        Coordinate (actualPosition)

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -50,10 +50,10 @@ update msg model =
                 { newModel | clock = clock } ! []
 
         KeyDown keyNum ->
-            { model | keys = Keys.updateKeys (Keys.Down keyNum) model.keys } ! []
+            { model | keys = Keys.updateFromKeyCode keyNum True model.keys } ! []
 
         KeyUp keyNum ->
-            { model | keys = Keys.updateKeys (Keys.Up keyNum) model.keys } ! []
+            { model | keys = Keys.updateFromKeyCode keyNum False model.keys } ! []
 
 
 tick : Time -> Model.Model -> Model.Model

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -2,7 +2,7 @@ module Model exposing (..)
 
 import Clock exposing (Clock)
 import Location
-import Keys
+import Keys exposing (GameKey(..))
 import Time exposing (Time)
 
 
@@ -40,34 +40,32 @@ updateLocation : Model -> Model
 updateLocation { clock, keys, location } =
     let
         vector =
-            buildVector keys
+            keysToVector keys
     in
         location
             |> Location.applyVector vector
             |> Model clock keys
 
 
-buildVector : Keys.Keys -> Location.Vector
-buildVector keys =
-    let
-        x =
-            0
-                |> addIfTrue keys.right 1
-                |> addIfTrue keys.left -1
-
-        y =
-            0
-                |> addIfTrue keys.up 1
-                |> addIfTrue keys.down -1
-    in
-        { dx = Location.Magnitude x
-        , dy = Location.Magnitude y
-        }
+keysToVector : Keys.Keys -> Location.Vector
+keysToVector keysDict =
+    keysDict
+        |> Keys.pressedKeys
+        |> List.foldr foldKey ( 0, 0 )
+        |> Location.toVector
 
 
-addIfTrue : Bool -> Float -> Float -> Float
-addIfTrue isTrue delta current =
-    if isTrue then
-        current + delta
-    else
-        current
+foldKey : Keys.GameKey -> ( Float, Float ) -> ( Float, Float )
+foldKey key ( x, y ) =
+    case key of
+        Down ->
+            ( x, y - 1 )
+
+        Left ->
+            ( x - 1, y )
+
+        Right ->
+            ( x + 1, y )
+
+        Up ->
+            ( x, y + 1 )


### PR DESCRIPTION
Making this a PR because it requires some explanation.

There is questionable value in the switch from `Keys` as a record to `Keys` as a dict.
Why did I do it then?

1. I got carried away
2. I wanted to have a Type around the each key, so when I add a new one the compiler will remind me to add a case for it.
 * The issue here is, the compiler can't remind me to check the `KeyCode` to make sure I'm interpreting it JSON response
3. I saw this pong example using a set and I liked the idea of being able to iterate over the pressed keys, instead of the way I was doing it by accessing individual fields on a record. This is actually better because now we are Folding over that list of pressed keys, and they are typed so we won't miss the chance to handle anything.

All in all, a smallish change, but has some significant architectural impact.